### PR TITLE
Make bootstrap title configurable and sticky

### DIFF
--- a/vendors/flowplayer.overlay.bootstrap.js
+++ b/vendors/flowplayer.overlay.bootstrap.js
@@ -6,15 +6,17 @@
     , $ = window.jQuery;
 
   flowplayer.overlay.bootstrap = function(api, root) {
-    var trigger = api.conf.overlay.trigger
-      , modalSize = api.conf.overlay.size
+    var conf = api.conf.overlay
+      , trigger = conf.trigger
+      , modalSize = conf.size
+      , modalTitle = conf.title
       , modal = $(
       '<div class="modal">'
         + '<div class="modal-dialog ' + (modalSize ? 'modal-' + modalSize : '') +  '">'
         + '<div class="modal-content">'
         + '<div class="modal-header">'
         + '<button type="button" class="close" data-dismiss="modal"><span>&times;</span></button>'
-        + '<h4 class="modal-title">Video</h4>'
+        + '<h4 class="modal-title">' + (modalTitle ? modalTitle : 'Video') + '</h4>'
         + '</div>'
         + '<div class="modal-body"></div>'
         + '</div>'
@@ -26,7 +28,9 @@
 
     modal.on('shown.bs.modal', function() {
       api.load(null, function() {
-        modal.find('.modal-title').text(api.video.title);
+        if (!modalTitle) {
+          modal.find('.modal-title').text(api.video.title);
+        }
       });
       common.addClass(root, 'is-open');
     });


### PR DESCRIPTION
Useful for playlists for instance:
- bootstrap modal title shows playlist title
- player shows video title

Or with single clips one can put the title just in the modal and avoid
hiding fp-title via CSS.
