### PR TITLE
Vendor/fancybox

### DIFF
--- a/example/fancybox.html
+++ b/example/fancybox.html
@@ -1,0 +1,67 @@
+
+<!doctype html>
+
+<html>
+
+<head>
+<meta charset="utf-8">
+<title>Flowplayer overlay plugin - Fancybox</title>
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.css">
+
+<link rel="stylesheet" href="//releases.flowplayer.org/6.0.5/skin/functional.css">
+
+<link rel="stylesheet" href="../flowplayer.overlay.css">
+<link rel="stylesheet" href="../vendors/flowplayer.overlay.fancybox.css">
+
+<style>
+body {
+  font-family: "myriad pro", tahoma, verdana, arial, sans-serif;
+  font-size: 14px;
+  margin: 0;
+  padding: 0;
+}
+#content {
+  margin: 50px auto;
+  max-width: 982px;
+}
+</style>
+
+<script src="//code.jquery.com/jquery-1.11.2.min.js"></script>
+
+<script src="//cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.min.js"></script>
+
+<script src="//releases.flowplayer.org/6.0.5/flowplayer.min.js"></script>
+<script src="//releases.flowplayer.org/hlsjs/flowplayer.hlsjs.min.js"></script>
+
+<script src="../flowplayer.overlay.js"></script>
+<script src="../vendors/flowplayer.overlay.fancybox.js"></script>
+
+<script>
+flowplayer.conf.overlay = {
+  vendor: "fancybox",
+  // closeBtn: false, // default: true (use fancybox close button)
+  // maxWidth: 600,   // default: not set
+  trigger: "#fancy"
+};
+</script>
+
+</head>
+
+<body>
+<div id="content">
+
+<p><button id="fancy" type="button">Play video</button></p>
+
+<div class="flowplayer" data-ratio="0.4167">
+  <video>
+    <source type="application/x-mpegurl" src="//edge.flowplayer.org/bauhaus.m3u8">
+    <source type="video/mp4" src="//edge.flowplayer.org/bauhaus.mp4">
+  </video>
+</div>
+
+</div>
+</body>
+
+</html>

--- a/vendors/flowplayer.overlay.fancybox.css
+++ b/vendors/flowplayer.overlay.fancybox.css
@@ -1,0 +1,16 @@
+.flowplayer.is-overlaid {
+  display: none;
+}
+.flowplayer.is-overlaid.is-open {
+  display: block;
+}
+
+.fancybox-flowplayer {
+  width: 80% !important;
+}
+.fancybox-flowplayer .fancybox-inner {
+  width: 100% !important;
+}
+.fancybox-flowplayer .flowplayer.is-loading {
+  background-color: #333;
+}

--- a/vendors/flowplayer.overlay.fancybox.js
+++ b/vendors/flowplayer.overlay.fancybox.js
@@ -1,0 +1,51 @@
+(function() {
+  /* global flowplayer */
+
+  var $ = window.jQuery;
+
+  flowplayer.overlay.fancybox = function(api, root) {
+    var conf = api.conf.overlay
+      , trigger = conf.trigger
+      , closeBtn = conf.closeBtn !== false
+      , id = $(root).attr('id')
+      , ctrlHeight = $(root).hasClass('fixed-controls')
+                       ? $('.fp-controls', root).height()
+                       : $(root).hasClass('no-toggle') ? 0 : 4;
+
+
+    if (!id) {
+      id = 'flowplayer-' + Math.random().toString().slice(2);
+      $(root).attr({id: id});
+    }
+    $(root).css({marginBottom: ctrlHeight}).toggleClass('is-closeable', !closeBtn);
+
+
+    $(trigger).fancybox({
+      href: '#' + id,
+      wrapCSS: 'fancybox-flowplayer',
+      type: 'inline',
+      closeBtn: closeBtn,
+      scrolling: 'no',
+      beforeShow: function () {
+        $(root).addClass('is-open');
+        if (conf.maxWidth) {
+          $(root).closest('.fancybox-flowplayer').css({maxWidth: conf.maxWidth});
+        }
+        api.load();
+      },
+      afterClose: function () {
+        if (api.ready) {
+          api.unload();
+        }
+      }
+    });
+
+    api.on('unload', function () {
+      $(root).removeClass('is-open');
+      if ($(root).parent().hasClass('fancybox-inner')) {
+        $.fancybox.close();
+      }
+    });
+
+  };
+})();


### PR DESCRIPTION
@nnarhinen 
- https://github.com/flowplayer/flowplayer-overlay/commit/4b8f70dff85be73214d6ddce6da5844f59c1121f is debatable, let me know what you think
- can https://github.com/flowplayer/flowplayer-overlay/blob/ae77ad1cc92e46fc2b22877debfe885ba8a750e1/vendors/flowplayer.overlay.fancybox.css go into the 'native' CSS; it's the only trick I found to keep the fancybox as responsive as a player would be, but from the user perspective it's much work for loading a tiny stylesheet. Otherwise I could add the needed rules from the native stylesheet, so only the vendor CSS would have to be loaded.
